### PR TITLE
Continue iterations until the backlog is depleted

### DIFF
--- a/src/capacity/core.cljc
+++ b/src/capacity/core.cljc
@@ -111,18 +111,28 @@
   "Works the backlog over multiple team iterations.
 
   Returns the remaining backlog (after all team iterations),
-          all backlogs (starting with the untouched backlog),
+          all backlog iterations (starting with the untouched backlog),
           all backlog summaries (after apply the team),
-          all team summaries (after applying to the backlog)
+          all team summaries (after application to the backlog)
   In that order."
   [backlog iterations]
-  (reduce (fn [[rem-backlog backlogs backlog-sums team-sums] team]
-            (let [[res-backlog res-team] (work-backlog rem-backlog team)
-                  backlog-sum (summarize-all rem-backlog res-backlog backlog)
-                  team-sum (summarize-all team res-team team)]
-              [res-backlog
+  (loop [rem-backlog backlog
+         backlogs []
+         backlog-sums []
+         team-sums []
+         rem-teams iterations]
+    (if (or (empty? rem-teams)
+            (every? exhausted? rem-backlog))
+      [rem-backlog
+       backlogs
+       backlog-sums
+       team-sums]
+      (let [team (first rem-teams)
+            [res-backlog res-team] (work-backlog rem-backlog team)
+            backlog-sum (summarize-all rem-backlog res-backlog backlog)
+            team-sum (summarize-all team res-team team)]
+        (recur res-backlog
                (conj backlogs rem-backlog)
                (conj backlog-sums backlog-sum)
-               (conj team-sums team-sum)]))
-          [backlog [] [] []]
-          iterations))
+               (conj team-sums team-sum)
+               (rest rem-teams))))))

--- a/src/capacity/core.cljc
+++ b/src/capacity/core.cljc
@@ -138,3 +138,17 @@
                (conj backlog-sums backlog-sum)
                (conj team-sums team-sum)
                (rest rem-teams))))))
+
+(defn work-backlog-entirely
+  "Works the backlog over all team iterations and then continues with the final
+  iteration until the backlog is exhausted.
+
+  Returns the remaining backlog (after all team iterations),
+          all backlog iterations (starting with the untouched backlog),
+          all backlog summaries (after apply the team),
+          all team summaries (after application to the backlog)
+  In that order."
+  [backlog iterations]
+  (work-backlog-iter backlog
+                     (concat iterations
+                             (-> iterations last repeat))))

--- a/src/capacity/core.cljc
+++ b/src/capacity/core.cljc
@@ -123,7 +123,7 @@
          backlog-sums []
          team-sums []
          rem-teams iterations]
-    (if (or (empty? rem-teams)
+    (if (or (empty? rem-teams) ;; TODO: Not sure if this is correct. May need 1 more iteration
             (every? exhausted? rem-backlog))
       [rem-backlog
        backlogs

--- a/src/capacity/core.cljc
+++ b/src/capacity/core.cljc
@@ -35,7 +35,8 @@
 (defrecord Project [name effort]
   Workable
   (work-out [proj team]
-    (merge-cp-solution (if (exhausted? proj)
+    (merge-cp-solution (if (or (exhausted? proj)
+                               (every? exhausted? team))
                          {}
                          (cp/solve (:effort proj)
                                    team))

--- a/src/capacity/core.cljc
+++ b/src/capacity/core.cljc
@@ -109,7 +109,8 @@
           backlog))
 
 (defn work-backlog-iter
-  "Works the backlog over multiple team iterations.
+  "Works the backlog over multiple team iterations until either the backlog or
+  iterations are exhausted.
 
   Returns the remaining backlog (after all team iterations),
           all backlog iterations (starting with the untouched backlog),

--- a/src/capacity/runner.clj
+++ b/src/capacity/runner.clj
@@ -21,14 +21,13 @@
                                         backlog-summary
                                         iter-team
                                         team-summary)))
-
 (defn run
   [filename]
   (let [[backlog iterations] (config/to-models filename)
         [remaining-backlog
          backlogs
          backlog-summaries
-         team-summaries] (work-backlog-iter backlog iterations)]
+         team-summaries] (work-backlog-entirely backlog iterations)]
     [remaining-backlog
      backlogs
      backlog-summaries

--- a/test/capacity/core_test.cljc
+++ b/test/capacity/core_test.cljc
@@ -293,7 +293,7 @@
                [(Project. :med {:app 0.0 :web 0.0})
                 (Project. :large {:app 5.0 :web 20.0})]
                [(Project. :med {:app 0.0 :web 0.0})
-                (Project. :large {:app 5.0 :web 5.0})]]
+                (Project. :large {:app 5.0 :web 5.0})]] ;; BUG: the last backlog should not have anything
               [(list (Change. :med
                               true
                               {:app -10.0 :web -5.0}

--- a/test/capacity/core_test.cljc
+++ b/test/capacity/core_test.cljc
@@ -82,7 +82,7 @@
 
                       [[frontback justback] [jan paul jean]]
                       [[(assoc frontback :effort {:app 5.0 :web 5.0 :ios 0.0})
-                        (assoc justback :effort {:app 3.0})]
+                        (assoc justback :effort {:app 3})]
                        [(assoc jan :capacity 0.0)
                         (assoc paul :capacity 0.0)
                         (assoc jean :capacity 0.0)]]

--- a/test/capacity/core_test.cljc
+++ b/test/capacity/core_test.cljc
@@ -181,49 +181,48 @@
 
 (t/deftest work-backlog-iter
   (are-equal sut/work-backlog-iter
-                    [[(Project. :med {:app 10 :web 10})
-                      (Project. :large {:app 15 :web 20})]
-                     [[(Eng. :pierre #{:app :web} 10)
-                       (Eng. :jan #{:web} 5)]
-                      [(Eng. :pierre #{:app :web} 10)
-                       (Eng. :jan #{:web} 5)]]]
+             [[(Project. :med {:app 10 :web 10})
+               (Project. :large {:app 15 :web 20})]
+              [[(Eng. :pierre #{:app :web} 10)
+                (Eng. :jan #{:web} 5)]
+               [(Eng. :pierre #{:app :web} 10)
+                (Eng. :jan #{:web} 5)]]]
 
-                    [[(Project. :med {:app 0.0 :web 0.0})
-                      (Project. :large {:app 5.0 :web 20.0})]
-                     [[(Project. :med {:app 10 :web 10})
-                       (Project. :large {:app 15 :web 20})]
-                      [(Project. :med {:app 0.0 :web 5.0})
-                       (Project. :large {:app 15.0 :web 20.0})]]
-                     [(list (Change. :med
-                                 true
-                                 {:app -10.0 :web -5.0}
-                                 0.75)
-                            (Change. :large
-                                     true
-                                     {:app 0.0 :web 0.0}
-                                     0.0))
-                      (list (Change. :med
-                                     true
-                                     {:app 0.0 :web -5.0}
-                                     1.0)
-                            (Change. :large
-                                     true
-                                     {:app -10.0 :web 0.0}
-                                     0.2857142857142857))]
-                     [(list (Change. :pierre
-                                     true
-                                     {:capacity -10.0}
-                                     1.0)
-                            (Change. :jan
-                                     true
-                                     {:capacity -5.0}
-                                     1.0))
-                      (list (Change. :pierre
-                                     true
-                                     {:capacity -10.0}
-                                     1.0)
-                            (Change. :jan
-                                     true
-                                     {:capacity -5.0}
-                                     1.0))]]))
-
+             [[(Project. :med {:app 0.0 :web 0.0})
+               (Project. :large {:app 5.0 :web 20.0})]
+              [[(Project. :med {:app 10 :web 10})
+                (Project. :large {:app 15 :web 20})]
+               [(Project. :med {:app 0.0 :web 5.0})
+                (Project. :large {:app 15.0 :web 20.0})]]
+              [(list (Change. :med
+                              true
+                              {:app -10.0 :web -5.0}
+                              0.75)
+                     (Change. :large
+                              true
+                              {:app 0.0 :web 0.0}
+                              0.0))
+               (list (Change. :med
+                              true
+                              {:app 0.0 :web -5.0}
+                              1.0)
+                     (Change. :large
+                              true
+                              {:app -10.0 :web 0.0}
+                              0.2857142857142857))]
+              [(list (Change. :pierre
+                              true
+                              {:capacity -10.0}
+                              1.0)
+                     (Change. :jan
+                              true
+                              {:capacity -5.0}
+                              1.0))
+               (list (Change. :pierre
+                              true
+                              {:capacity -10.0}
+                              1.0)
+                     (Change. :jan
+                              true
+                              {:capacity -5.0}
+                              1.0))]]))

--- a/test/capacity/core_test.cljc
+++ b/test/capacity/core_test.cljc
@@ -181,6 +181,7 @@
 
 (t/deftest work-backlog-iter
   (are-equal sut/work-backlog-iter
+             ;; Incomplete
              [[(Project. :med {:app 10 :web 10})
                (Project. :large {:app 15 :web 20})]
               [[(Eng. :pierre #{:app :web} 10)
@@ -193,15 +194,15 @@
               [[(Project. :med {:app 10 :web 10})
                 (Project. :large {:app 15 :web 20})]
                [(Project. :med {:app 0.0 :web 5.0})
-                (Project. :large {:app 15.0 :web 20.0})]]
+                (Project. :large {:app 15 :web 20})]]
               [(list (Change. :med
                               true
                               {:app -10.0 :web -5.0}
                               0.75)
                      (Change. :large
                               true
-                              {:app 0.0 :web 0.0}
-                              0.0))
+                              {:app 0 :web 0}
+                              0))
                (list (Change. :med
                               true
                               {:app 0.0 :web -5.0}
@@ -222,6 +223,137 @@
                               true
                               {:capacity -10.0}
                               1.0)
+                     (Change. :jan
+                              true
+                              {:capacity -5.0}
+                              1.0))]]
+
+             ;; Complete
+             [[(Project. :med {:app 5 :web 5})
+               (Project. :large {:app 5 :web 5})]
+              [[(Eng. :pierre #{:app :web} 10)
+                (Eng. :jan #{:web} 5)]
+               [(Eng. :pierre #{:app :web} 10)
+                (Eng. :jan #{:web} 5)]]]
+
+             [[(Project. :med {:app 0.0 :web 0.0})
+               (Project. :large {:app 0.0 :web 0.0})]
+              [[(Project. :med {:app 5 :web 5})
+                (Project. :large {:app 5 :web 5})]
+               [(Project. :med {:app 0.0 :web 0.0})
+                (Project. :large {:app 0.0 :web 5.0})]]
+              [(list (Change. :med
+                              true
+                              {:app -5.0 :web -5.0}
+                              1.0)
+                     (Change. :large
+                              true
+                              {:app -5.0 :web 0.0}
+                              0.5))
+               (list (Change. :med
+                              true
+                              {:app 0.0 :web 0.0}
+                              1.0)
+                     (Change. :large
+                              true
+                              {:app 0.0 :web -5.0}
+                              1.0))]
+              [(list (Change. :pierre
+                              true
+                              {:capacity -10.0}
+                              1.0)
+                     (Change. :jan
+                              true
+                              {:capacity -5.0}
+                              1.0))
+               (list (Change. :pierre
+                              true
+                              {:capacity 0.0}
+                              0.0)
+                     (Change. :jan
+                              true
+                              {:capacity -5.0}
+                              1.0))]]))
+
+(t/deftest work-backlog-entirely
+  (are-equal sut/work-backlog-entirely
+             [[(Project. :med {:app 10 :web 10})
+               (Project. :large {:app 15 :web 20})]
+              [[(Eng. :pierre #{:app :web} 10)
+                (Eng. :jan #{:web} 5)]
+               [(Eng. :pierre #{:app :web} 10)
+                (Eng. :jan #{:web} 5)]]]
+
+             [[(Project. :med {:app 0.0 :web 0.0})
+               (Project. :large {:app 0.0 :web 0.0})]
+              [[(Project. :med {:app 10 :web 10})
+                (Project. :large {:app 15 :web 20})]
+               [(Project. :med {:app 0.0 :web 5.0})
+                (Project. :large {:app 15 :web 20})]
+               [(Project. :med {:app 0.0 :web 0.0})
+                (Project. :large {:app 5.0 :web 20.0})]
+               [(Project. :med {:app 0.0 :web 0.0})
+                (Project. :large {:app 5.0 :web 5.0})]]
+              [(list (Change. :med
+                              true
+                              {:app -10.0 :web -5.0}
+                              0.75)
+                     (Change. :large
+                              true
+                              {:app 0 :web 0}
+                              0))
+               (list (Change. :med
+                              true
+                              {:app 0.0 :web -5.0}
+                              1.0)
+                     (Change. :large
+                              true
+                              {:app -10.0 :web 0.0}
+                              0.2857142857142857))
+               (list (Change. :med
+                              true
+                              {:app 0.0 :web 0.0}
+                              1.0)
+                     (Change. :large
+                              true
+                              {:app 0.0 :web -15.0}
+                              0.7142857142857143))
+               (list (Change. :med
+                              true
+                              {:app 0.0 :web 0.0}
+                              1.0)
+                     (Change. :large
+                              true
+                              {:app -5.0 :web -5.0}
+                              1.0))]
+              [(list (Change. :pierre
+                              true
+                              {:capacity -10.0}
+                              1.0)
+                     (Change. :jan
+                              true
+                              {:capacity -5.0}
+                              1.0))
+               (list (Change. :pierre
+                              true
+                              {:capacity -10.0}
+                              1.0)
+                     (Change. :jan
+                              true
+                              {:capacity -5.0}
+                              1.0))
+               (list (Change. :pierre
+                              true
+                              {:capacity -10.0}
+                              1.0)
+                     (Change. :jan
+                              true
+                              {:capacity -5.0}
+                              1.0))
+               (list (Change. :pierre
+                              true
+                              {:capacity -5.0}
+                              0.5)
                      (Change. :jan
                               true
                               {:capacity -5.0}


### PR DESCRIPTION
Add ability to, if we run out of iterations before projects then use the final iteration to complete all projects.

Closes #3 .